### PR TITLE
274 sweetalert bei gast einfügen

### DIFF
--- a/src/views/WishList.vue
+++ b/src/views/WishList.vue
@@ -169,6 +169,7 @@ export default {
 
       return this.eventDjId === djID
     },
+
     sortedRequest() {
       return this.requests
         .filter((request) => request.open !== false)
@@ -185,12 +186,14 @@ export default {
     findOriginalRequest(request) {
       return this.requests.find((r) => r.id === request.id)
     },
+
     // VoteButtonClick wird gehandelt
     handleClick(request) {
       this.toggleVote(request)
       //Click = Disable , Enable durch watcher bei Veränderung in Requests.userHasVoted
       request.isButtonDisabled = true
     },
+
     async toggleVote(request) {
       const newrequest = { ...request } //abkoppeln!
       this.votes[request.id] = true
@@ -263,6 +266,7 @@ export default {
       return likes === 1 ? 'Stimme gezählt' : 'Stimmen gezählt'
     }
   },
+
   watch: {
     // Requests werden überwacht ob sich request.userHasVoted ändert
     // bei Änderung -> Enable VoteButton

--- a/src/views/guest/GuestStart.vue
+++ b/src/views/guest/GuestStart.vue
@@ -2,7 +2,7 @@
   <h3>Schön, dass du da bist!</h3>
   <p v-if="!aktivEvent">
     Das Event hat noch nicht begonnen, oder ist bereits gelöscht.<br />
-    Versuche es später nochmal.
+    Bitte versuche es später nochmal.
   </p>
   <p v-if="aktivEvent">
     Herzlich willkommen bei Hulaloop, die App wo Musikwünsche wahr werden. Gib einfach deinen Namen
@@ -36,9 +36,12 @@ export default {
     }
   },
 
-  created() {
+  async created() {
+    localStorage.removeItem('currentEventId')
+
     // Beim laden der Seite überprüfen, ob Name im Local Storage bereits gespeichert ist und die eventId abgreifen und das eventObjekt abrufen.
-    this.checkIfNameInLocalStorage(), this.getEventDataFromUrl()
+    await this.getEventDataFromUrl()
+    this.checkIfNameInLocalStorage()
   },
 
   methods: {
@@ -109,8 +112,8 @@ export default {
             localStorage.setItem('eventData', JSON.stringify(eventData))
             console.log('Event-Daten:', eventData)
           } else {
-            alert('Dieses Event ist nicht aktiv.')
             localStorage.removeItem('eventData')
+            alert('Dieses Event ist nicht aktiv.')
           }
         } catch (error) {
           console.error('Fehler:', error)

--- a/src/views/guest/GuestStart.vue
+++ b/src/views/guest/GuestStart.vue
@@ -38,6 +38,7 @@ export default {
 
   async created() {
     localStorage.removeItem('currentEventId')
+    localStorage.removeItem('activeDjId')
 
     // Beim laden der Seite überprüfen, ob Name im Local Storage bereits gespeichert ist und die eventId abgreifen und das eventObjekt abrufen.
     await this.getEventDataFromUrl()


### PR DESCRIPTION
Wenn guestData in storage vorhanden ist, wird gast direkt auf die overview geleitet.

Wenn currentEventId oder activeDjId im storage ist, wird diese auf der start seite gelöscht. 